### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -103,7 +103,7 @@ def combine(h)
   }.sort_by { |h| h[:start_date] }
 end
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 
 # http://api.parldata.eu/sk/nrsr/organizations?where={"classification":"chamber"}
 terms = noko_q('organizations', where: %Q[{"classification":"chamber"}] ).map do |chamber|


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593